### PR TITLE
 No alert for `getToolTips`

### DIFF
--- a/fitnesse/resources/bootstrap-plus/js/bootstrap-plus.js
+++ b/fitnesse/resources/bootstrap-plus/js/bootstrap-plus.js
@@ -776,7 +776,6 @@ function getToolTips(callback) {
         contentType: 'charset=utf-8',
         success: data => callback(data),
         error: function (xhr) {
-            alert('An error ' + xhr.status + ' occurred. Look at the console (F12 or Ctrl+Shift+I) for more information.');
             console.log('Error code: ' + xhr.status, xhr);
         }
     });


### PR DESCRIPTION
This alert is very annoying if Fitnesse Pages are saved to AWS S3 for later viewing w/o the Fitnesse itself